### PR TITLE
Issue 52 preview window reopened

### DIFF
--- a/frames.py
+++ b/frames.py
@@ -53,7 +53,8 @@ height, width = (logo.height(), logo.width())
 titleLogo = Canvas(topFrame, bg="#16e4d3", width=width, height=height, highlightthickness=0)
 titleLogo.pack(side = LEFT)
 titleLogo.create_image(0, -22, image=logo, anchor=NW)
-analytics = Label(topFrame, text="Analytics", bg="#16e4d3", font="Bahnschrift 30 bold", fg = "#FFFF00", pady = 20)
+font_tuple = ("Microsoft Sans Serif", 30, "bold")
+analytics = Label(topFrame, text="Analytics", bg="#16e4d3", font=font_tuple, fg = "#FFFF00")
 analytics.pack(side = LEFT)
 
 #Labels in the 'select file' frames


### PR DESCRIPTION
Just a few visual improvements to GUI and Preview Window. Tkinter doesn't have Encode Sans Compressed in it's font library. Attempted to import a .ttf using pyglet, but it caused conflicts with TkinterDnD so I scrapped it and just used the most similar font I could find that is in the Tkinter font library. I expect to see merge conflicts, I will deal with those...