### PR TITLE
Issue 79 make a remove button for each iNat file

### DIFF
--- a/frames.py
+++ b/frames.py
@@ -373,4 +373,5 @@ midFrameSDS.bind('<Leave>', on_leaveSDS)
 midFrameiNat.bind('<Enter>', on_enteriNat)
 midFrameiNat.bind('<Leave>', on_leaveiNat)
 
+root.resizable(False, False)
 root.mainloop()


### PR DESCRIPTION
Closes #79
In this PR:
- individual remove buttons for each iNat filepath
- most recently added iNat file gets displayed below the previous (instead of above)

I have also set the window to be non-resizable by the user. This is due to a mixture of .grid and .pack being used to arrange widgets, which do not interact smoothly when resizing. Therefore making the window resizable will probably be a bit time consuming. If time permits, we can revisit this at the end.