### PR TITLE
Issue 52 preview window reopened

### DIFF
--- a/frames.py
+++ b/frames.py
@@ -135,7 +135,7 @@ def previewWindow(previewInput):
     newWindow.title("Preview Window")
     newWindow.geometry("700x500")
     newWindow.iconbitmap("seahorse.ico")
-    displayText = Text(newWindow, height=15, width=50, font="Bahnschrift 14")
+    displayText = Text(newWindow, height=15, width=50, font="Bahnschrift 14", wrap=WORD)
     displayText.pack(pady=20)
     displayText.insert(END, previewInput[1])
     displayText.pack_propagate(0)


### PR DESCRIPTION
- 'Download results' button brings up a pop up which prompts user to select location and name of file.
- Changed widget of display output to a text widget so I could add a scroll bar for when preview is longer than window length